### PR TITLE
Allow sentiment values containing #

### DIFF
--- a/lib/textmood.rb
+++ b/lib/textmood.rb
@@ -157,7 +157,7 @@ class TextMood
 
     sentiment_file = File.new(path, "r:UTF-8")
     while (line = sentiment_file.gets)
-      unless (line.match(/\s*#/))
+      unless (line.match(/^\s*#/))
         parsed_line = line.chomp.split(/\s*([\d.-]+):\s*([^\s].*)/)
         if parsed_line.size == 3
           score = parsed_line[1]


### PR DESCRIPTION
Sentiment values with a # in it are skipped when loading from the file. This change will allow sentiment values with a # in it and also allow comments, which I think is the original intent of the statement which matches on a #.